### PR TITLE
Prevent Invalid Argument error in IE

### DIFF
--- a/jquery.jscroll.js
+++ b/jquery.jscroll.js
@@ -53,7 +53,7 @@
 		{
 			this.min = $element.offset().top;
 			this.max = $element.parent().height() - $element.outerHeight();
-			this.originalMargin = parseInt($element.css("margin-top"));
+			this.originalMargin = parseInt($element.css("margin-top"), 10) || 0;
 			
 			this.getMargin = function ($window)
 			{


### PR DESCRIPTION
In my application $element.css("margin-top") was returning "auto" in IE, which causes parseInt to return NaN. Later on when that value is used as originalMargin within getMargin somewhere IE would raise an error. My change prevents the error by ensuring originalMargin is a number. I also pass the base (10) to parseInt to avoid any issues like this: http://stackoverflow.com/questions/850341/workarounds-for-javascript-parseint-octal-bug
