### PR TITLE
Consider top option when calculating new margin

### DIFF
--- a/jquery.jscroll.js
+++ b/jquery.jscroll.js
@@ -3,7 +3,7 @@
 // ####### Plugin:      jScroll                                                 #######
 // ####### Author:      William Duffy                                           #######
 // ####### Website:     http://www.wduffy.co.uk/jScroll                         #######
-// ####### Version:     1.1	                                                    #######
+// ####### Version:     1.1                                                     #######
 // #######                                                                      #######
 // ####### Copyright (c) 2011, William Duffy - www.wduffy.co.uk                 #######
 // #######                                                                      #######
@@ -30,51 +30,51 @@
 // #######                                                                      #######
 // ####################################################################################
 (function($) {
-    
+
     // Public: jScroll Plugin
     $.fn.jScroll = function(options) {
 
         var opts = $.extend({}, $.fn.jScroll.defaults, options);
 
         return this.each(function() {
-			var $element = $(this);
-			var $window = $(window);
-			var locator = new location($element);
-			
-			$window.scroll(function() {
-				$element
-					.stop()
-					.animate(locator.getMargin($window), opts.speed);
-			});
+            var $element = $(this);
+            var $window = $(window);
+            var locator = new location($element);
+
+            $window.scroll(function() {
+                $element
+                    .stop()
+                    .animate(locator.getMargin($window), opts.speed);
+            });
         });
-		
-		// Private 
-		function location($element)
-		{
-			this.min = $element.offset().top;
-			this.originalMargin = parseInt($element.css("margin-top"), 10) || 0;
-			
-			this.getMargin = function ($window)
-			{
-				var max = $element.parent().height() - $element.outerHeight();
-				var margin = this.originalMargin;
-			
-				if ($window.scrollTop() >= this.min - opts.top)
-					margin = margin + opts.top + $window.scrollTop() - this.min; 
-				
-				if (margin > max)
-					margin = max;
-			
-				return ({"marginTop" : margin + 'px'});
-			}
-		}	   
-		
+
+        // Private
+        function location($element)
+        {
+            this.min = $element.offset().top;
+            this.originalMargin = parseInt($element.css("margin-top"), 10) || 0;
+
+            this.getMargin = function ($window)
+            {
+                var max = $element.parent().height() - $element.outerHeight();
+                var margin = this.originalMargin;
+
+                if ($window.scrollTop() >= this.min - opts.top)
+                    margin = margin + opts.top + $window.scrollTop() - this.min;
+
+                if (margin > max)
+                    margin = max;
+
+                return ({"marginTop" : margin + 'px'});
+            }
+        }
+
     };
 
     // Public: Default values
     $.fn.jScroll.defaults = {
-        speed	:	"slow",
-		top		:	10
+        speed   :   "slow",
+        top     :   10
     };
 
 })(jQuery);

--- a/jquery.jscroll.js
+++ b/jquery.jscroll.js
@@ -40,11 +40,23 @@
             var $element = $(this);
             var $window = $(window);
             var locator = new location($element);
+            var didScroll = false;
+            var timer = false;
 
-            $window.scroll(function() {
-                $element
-                    .stop()
-                    .animate(locator.getMargin($window), opts.speed);
+            // http://ejohn.org/blog/learning-from-twitter/
+            $(window).scroll(function() {
+                if(!didScroll) {
+                    timer = setInterval(function() {
+                        if ( didScroll ) {
+                            didScroll = false;
+                            clearTimeout(timer);
+                            $element
+                            .stop()
+                            .animate(locator.getMargin($window), opts.speed);
+                        }
+                    }, 250);
+                }
+                didScroll = true;
             });
         });
 

--- a/jquery.jscroll.js
+++ b/jquery.jscroll.js
@@ -59,7 +59,7 @@
 				var max = $element.parent().height() - $element.outerHeight();
 				var margin = this.originalMargin;
 			
-				if ($window.scrollTop() >= this.min)
+				if ($window.scrollTop() >= this.min - opts.top)
 					margin = margin + opts.top + $window.scrollTop() - this.min; 
 				
 				if (margin > max)

--- a/jquery.jscroll.js
+++ b/jquery.jscroll.js
@@ -78,7 +78,7 @@
                     margin = max;
 
                 return ({"marginTop" : margin + 'px'});
-            }
+            };
         }
 
     };

--- a/sample/index.html
+++ b/sample/index.html
@@ -7,7 +7,8 @@
 	<script type="text/javascript">
 		
 		$().ready(function() {
-			$(".scroll").jScroll();
+            $(".scroll").jScroll();
+            $(".scroll-top-200").jScroll({top: 200});
 		});
 		
 	</script>
@@ -24,7 +25,7 @@
 			width: 70%;
 			}
 		
-		.scroll {
+		.scroll-top-200, .scroll {
 			float: left; 
 			width: 21%; 
 			padding: 0% 2% 2%; 
@@ -576,6 +577,277 @@
 	<div class="scroll">
 		<h2>Scroll Element B</h2>
 		Scroll down/up to see me smoothly reposition myself and keep in view.<br><br>
+		jScroll by William Duffy<br />
+		<a href="http://www.wduffy.co.uk/">www.wduffy.co.uk</a>
+	</div>
+
+	<div class="clear"><!-- clear --></div>
+</div>
+
+<div class="container">
+	<div class="text">
+		<h1>Scroll Container C</h1>
+		<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam sit 
+	amet nulla sem, nec consectetur velit. Aliquam tempus, nisl sed 
+	fringilla rutrum, tellus risus molestie nisl, nec molestie nunc tellus 
+	vitae urna. Sed ornare mollis metus ac eleifend. Nulla at purus leo. 
+	Vivamus egestas lorem vitae risus interdum vitae vehicula libero 
+	aliquam. Vestibulum cursus est vel tellus consectetur rutrum condimentum
+	 magna euismod. In venenatis dapibus dui, non laoreet tellus consectetur
+	 id. Fusce ut ornare turpis. Suspendisse in leo quis massa auctor 
+	laoreet ut eu lacus. Fusce cursus gravida sapien, non tincidunt risus 
+	convallis vel. Curabitur massa lorem, placerat quis ultrices at, 
+	volutpat scelerisque lorem. Praesent ut nibh nec felis facilisis 
+	fringilla. Etiam ullamcorper varius scelerisque. Suspendisse massa elit,
+	 eleifend at ultricies semper, fringilla eu velit. In aliquam vulputate 
+	sapien, rhoncus mattis nisl porta eu. In dui eros, luctus non faucibus 
+	at, placerat pellentesque justo. In quis lacus interdum magna rhoncus 
+	mollis non et nunc. Vivamus convallis tempor porttitor.</p>
+		<p>Quisque rhoncus volutpat semper. Mauris in venenatis neque. Ut 
+	sodales hendrerit augue vel feugiat. Fusce ante sapien, sodales et 
+	porttitor et, malesuada vitae augue. Suspendisse varius, quam in tempus 
+	aliquet, neque dolor ultricies libero, et tristique dolor nulla a justo.
+	 Nunc sit amet purus felis, id hendrerit quam. Vestibulum semper 
+	vulputate arcu ut gravida. Praesent et nisi nec lectus elementum porta. 
+	Nunc pulvinar mi at justo vulputate bibendum. Nunc dictum, nisi ac 
+	auctor volutpat, quam risus fringilla elit, in iaculis tortor felis et 
+	nulla. Pellentesque lacinia nisl at velit suscipit at adipiscing ligula 
+	gravida. Nam eu dolor ante, sit amet blandit ipsum. Donec quis enim 
+	ligula. Mauris auctor nibh non elit sollicitudin consequat. Phasellus 
+	semper sem et dui lobortis faucibus.</p>
+		<p>Sed dolor massa, placerat eget vehicula vel, pharetra vel leo. 
+	Suspendisse facilisis fermentum vulputate. Nulla eu pharetra diam. 
+	Aliquam tincidunt nunc sed diam congue a mollis nibh fringilla. Aliquam 
+	dictum enim vitae nulla pharetra molestie. Sed mollis, lacus porttitor 
+	ullamcorper pretium, dolor felis tempor elit, et tincidunt orci erat 
+	vitae felis. Maecenas pharetra accumsan sapien non auctor. Curabitur non
+	 risus at lacus egestas facilisis scelerisque gravida tortor. Duis 
+	lacinia dapibus arcu ac molestie. Proin magna neque, posuere ultricies 
+	fringilla sit amet, consectetur vel nibh. Nam quis augue eros, ac mollis
+	 neque. Fusce tincidunt vehicula auctor.</p>
+		<p>Morbi vel sapien arcu, a lobortis mauris. Phasellus placerat turpis 
+	at velit pretium adipiscing. Nullam viverra pretium odio in eleifend. 
+	Nullam et eleifend sem. Sed massa ante, sollicitudin a lacinia ut, 
+	eleifend sed sem. Sed quis lectus purus. Phasellus iaculis lectus et 
+	eros dictum id auctor elit porttitor. In volutpat, felis rutrum blandit 
+	fringilla, velit lacus imperdiet dui, nec pharetra lacus lorem ac 
+	sapien. Duis imperdiet, leo et adipiscing vestibulum, orci felis 
+	vulputate nunc, eu laoreet purus ipsum at lorem. Donec quis leo enim. 
+	Vivamus hendrerit elit purus, in laoreet mauris. Etiam tempus 
+	condimentum felis, nec pretium nisi porta eu. Nam vitae velit enim. 
+	Aliquam quis magna eros. Morbi sit amet velit lectus, nec euismod 
+	mauris. Nam faucibus tortor porta tortor interdum non tristique erat 
+	semper.</p>
+		<p>Sed elit tellus, malesuada mattis mattis ac, hendrerit at metus. 
+	Maecenas lobortis, dolor non tincidunt auctor, diam lacus aliquam purus,
+	 nec dapibus velit elit id tortor. Cras massa dolor, tempor ac viverra 
+	ac, rhoncus in nibh. Maecenas pellentesque elit ac mi cursus suscipit. 
+	Morbi eleifend lacus ut est auctor ac molestie eros venenatis. Aenean 
+	dignissim, massa ultricies venenatis pulvinar, velit tortor sodales 
+	urna, in molestie erat libero vitae arcu. Phasellus enim nunc, dictum ac
+	 volutpat at, eleifend tristique eros. Nunc eu libero felis, sit amet 
+	pellentesque tortor. Cras in massa augue. Ut varius, velit blandit 
+	laoreet malesuada, tortor mauris accumsan elit, a interdum libero lectus
+	 sed mauris. Donec vitae sem a elit ultricies dictum. Donec elementum 
+	sagittis orci nec hendrerit. Cras convallis volutpat orci, quis iaculis 
+	justo hendrerit vel. Mauris ornare bibendum eros id placerat.</p>
+		<p>Pellentesque habitant morbi tristique senectus et netus et malesuada
+	 fames ac turpis egestas. Cras ac cursus orci. Nullam fermentum congue 
+	ante at dignissim. Duis rhoncus sollicitudin erat, ut eleifend magna 
+	ullamcorper ac. Fusce vitae commodo erat. Duis elementum risus ac lacus 
+	gravida posuere. Aliquam eu eros dui, quis fermentum magna. Vestibulum 
+	in arcu tortor, iaculis consectetur nisl. Vestibulum felis erat, 
+	molestie in congue id, sagittis nec ipsum. Class aptent taciti sociosqu 
+	ad litora torquent per conubia nostra, per inceptos himenaeos. Aliquam 
+	mollis tristique libero a mattis. Ut a pellentesque risus.</p>
+		<p>Cras consectetur est sit amet nulla auctor facilisis. Vivamus 
+	pretium bibendum viverra. Curabitur congue quam et felis consectetur a 
+	adipiscing libero elementum. Vestibulum ante ipsum primis in faucibus 
+	orci luctus et ultrices posuere cubilia Curae; Quisque lobortis, dui 
+	vestibulum dapibus placerat, tortor risus viverra mauris, et molestie 
+	ipsum nunc ut erat. Mauris mollis, massa ac consectetur facilisis, nulla
+	 lacus gravida arcu, vel adipiscing leo diam auctor enim. Morbi iaculis 
+	scelerisque nulla. Vestibulum vitae velit ante. Cum sociis natoque 
+	penatibus et magnis dis parturient montes, nascetur ridiculus mus. 
+	Maecenas varius eleifend commodo. Donec eu nulla risus, vel scelerisque 
+	ante. Proin a purus nibh, eu adipiscing erat. Ut vestibulum enim eget mi
+	 dictum aliquet. Cras consectetur, augue a blandit rutrum, arcu est 
+	venenatis velit, non vulputate ligula arcu quis ante. Praesent lectus 
+	mauris, consequat sit amet feugiat vitae, commodo sit amet sem.</p>
+		<p>Pellentesque molestie tincidunt leo, eu blandit mauris iaculis 
+	vitae. Donec sed convallis felis. Curabitur fringilla consectetur augue 
+	id viverra. Integer fringilla est et arcu tincidunt bibendum facilisis 
+	lectus ullamcorper. Suspendisse et nisi sed enim ullamcorper rutrum. Nam
+	 leo erat, ultricies in fringilla a, condimentum a ipsum. Proin nunc 
+	metus, tincidunt quis sagittis ut, vulputate at odio. Nulla pellentesque
+	 vulputate lectus, quis scelerisque nisi rutrum porta. Nam blandit 
+	tristique nisi. Donec placerat tristique nibh, ac placerat erat bibendum
+	 in. Mauris posuere, ipsum vel eleifend blandit, neque arcu cursus 
+	velit, ut faucibus nisl velit quis magna. Aliquam vulputate, mi ac 
+	pulvinar tempus, elit urna eleifend dolor, iaculis auctor nibh elit ac 
+	sem. Nam volutpat erat vel neque pulvinar commodo ac sed erat. Nam sed 
+	erat eu risus facilisis viverra a vel lectus. Curabitur consectetur nunc
+	 accumsan ligula aliquam ut ullamcorper arcu molestie.</p>
+		<p>Cras a augue massa. Praesent feugiat aliquam justo, ut gravida quam 
+	feugiat tristique. Suspendisse potenti. Aliquam erat volutpat. Sed 
+	sollicitudin sodales magna, sed rhoncus dui lacinia vel. Phasellus in 
+	nisi dui. Morbi condimentum, eros eget faucibus commodo, libero nulla 
+	tristique lacus, a varius ligula diam sagittis mauris. Suspendisse 
+	ultrices, sem et iaculis semper, magna erat porttitor nunc, vel rutrum 
+	nunc sapien eu nisl. Suspendisse egestas ullamcorper cursus. Nam 
+	scelerisque adipiscing accumsan. In hac habitasse platea dictumst. Ut 
+	aliquet nisi in elit fermentum rutrum. Curabitur sem leo, feugiat vel 
+	euismod eu, adipiscing sit amet sem. Quisque tempus sapien vulputate 
+	magna vulputate bibendum ullamcorper est congue. Aenean vitae nulla a 
+	lorem rutrum bibendum sit amet id mauris. Pellentesque habitant morbi 
+	tristique senectus et netus et malesuada fames ac turpis egestas. Duis a
+	 risus ac ligula pulvinar placerat nec ac felis. Quisque a massa elit, 
+	vel ornare felis. Quisque placerat, dui vel tristique facilisis, sem 
+	lectus tincidunt neque, ac iaculis lectus leo id felis.</p>
+		<p>Vestibulum sed felis diam. Vivamus ac mi semper massa tincidunt 
+	placerat. Phasellus consectetur, augue nec faucibus lobortis, diam 
+	ligula pharetra nisi, ut consequat magna leo porta mauris. Nunc vitae 
+	dolor nisi. Sed at neque nec arcu eleifend suscipit. Fusce pellentesque 
+	purus ullamcorper orci scelerisque adipiscing. Curabitur placerat mi 
+	eget tortor hendrerit vehicula in sit amet eros. Vestibulum ante ipsum 
+	primis in faucibus orci luctus et ultrices posuere cubilia Curae; Proin 
+	nec justo ac dolor dignissim pulvinar feugiat in sapien. Suspendisse 
+	tincidunt tristique risus, sed faucibus arcu sagittis eu. Nulla et 
+	dignissim tortor. Suspendisse dictum ornare velit, at viverra mi 
+	condimentum a.</p>
+		<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam sit 
+	amet nulla sem, nec consectetur velit. Aliquam tempus, nisl sed 
+	fringilla rutrum, tellus risus molestie nisl, nec molestie nunc tellus 
+	vitae urna. Sed ornare mollis metus ac eleifend. Nulla at purus leo. 
+	Vivamus egestas lorem vitae risus interdum vitae vehicula libero 
+	aliquam. Vestibulum cursus est vel tellus consectetur rutrum condimentum
+	 magna euismod. In venenatis dapibus dui, non laoreet tellus consectetur
+	 id. Fusce ut ornare turpis. Suspendisse in leo quis massa auctor 
+	laoreet ut eu lacus. Fusce cursus gravida sapien, non tincidunt risus 
+	convallis vel. Curabitur massa lorem, placerat quis ultrices at, 
+	volutpat scelerisque lorem. Praesent ut nibh nec felis facilisis 
+	fringilla. Etiam ullamcorper varius scelerisque. Suspendisse massa elit,
+	 eleifend at ultricies semper, fringilla eu velit. In aliquam vulputate 
+	sapien, rhoncus mattis nisl porta eu. In dui eros, luctus non faucibus 
+	at, placerat pellentesque justo. In quis lacus interdum magna rhoncus 
+	mollis non et nunc. Vivamus convallis tempor porttitor.</p>
+		<p>Quisque rhoncus volutpat semper. Mauris in venenatis neque. Ut 
+	sodales hendrerit augue vel feugiat. Fusce ante sapien, sodales et 
+	porttitor et, malesuada vitae augue. Suspendisse varius, quam in tempus 
+	aliquet, neque dolor ultricies libero, et tristique dolor nulla a justo.
+	 Nunc sit amet purus felis, id hendrerit quam. Vestibulum semper 
+	vulputate arcu ut gravida. Praesent et nisi nec lectus elementum porta. 
+	Nunc pulvinar mi at justo vulputate bibendum. Nunc dictum, nisi ac 
+	auctor volutpat, quam risus fringilla elit, in iaculis tortor felis et 
+	nulla. Pellentesque lacinia nisl at velit suscipit at adipiscing ligula 
+	gravida. Nam eu dolor ante, sit amet blandit ipsum. Donec quis enim 
+	ligula. Mauris auctor nibh non elit sollicitudin consequat. Phasellus 
+	semper sem et dui lobortis faucibus.</p>
+		<p>Sed dolor massa, placerat eget vehicula vel, pharetra vel leo. 
+	Suspendisse facilisis fermentum vulputate. Nulla eu pharetra diam. 
+	Aliquam tincidunt nunc sed diam congue a mollis nibh fringilla. Aliquam 
+	dictum enim vitae nulla pharetra molestie. Sed mollis, lacus porttitor 
+	ullamcorper pretium, dolor felis tempor elit, et tincidunt orci erat 
+	vitae felis. Maecenas pharetra accumsan sapien non auctor. Curabitur non
+	 risus at lacus egestas facilisis scelerisque gravida tortor. Duis 
+	lacinia dapibus arcu ac molestie. Proin magna neque, posuere ultricies 
+	fringilla sit amet, consectetur vel nibh. Nam quis augue eros, ac mollis
+	 neque. Fusce tincidunt vehicula auctor.</p>
+		<p>Morbi vel sapien arcu, a lobortis mauris. Phasellus placerat turpis 
+	at velit pretium adipiscing. Nullam viverra pretium odio in eleifend. 
+	Nullam et eleifend sem. Sed massa ante, sollicitudin a lacinia ut, 
+	eleifend sed sem. Sed quis lectus purus. Phasellus iaculis lectus et 
+	eros dictum id auctor elit porttitor. In volutpat, felis rutrum blandit 
+	fringilla, velit lacus imperdiet dui, nec pharetra lacus lorem ac 
+	sapien. Duis imperdiet, leo et adipiscing vestibulum, orci felis 
+	vulputate nunc, eu laoreet purus ipsum at lorem. Donec quis leo enim. 
+	Vivamus hendrerit elit purus, in laoreet mauris. Etiam tempus 
+	condimentum felis, nec pretium nisi porta eu. Nam vitae velit enim. 
+	Aliquam quis magna eros. Morbi sit amet velit lectus, nec euismod 
+	mauris. Nam faucibus tortor porta tortor interdum non tristique erat 
+	semper.</p>
+		<p>Sed elit tellus, malesuada mattis mattis ac, hendrerit at metus. 
+	Maecenas lobortis, dolor non tincidunt auctor, diam lacus aliquam purus,
+	 nec dapibus velit elit id tortor. Cras massa dolor, tempor ac viverra 
+	ac, rhoncus in nibh. Maecenas pellentesque elit ac mi cursus suscipit. 
+	Morbi eleifend lacus ut est auctor ac molestie eros venenatis. Aenean 
+	dignissim, massa ultricies venenatis pulvinar, velit tortor sodales 
+	urna, in molestie erat libero vitae arcu. Phasellus enim nunc, dictum ac
+	 volutpat at, eleifend tristique eros. Nunc eu libero felis, sit amet 
+	pellentesque tortor. Cras in massa augue. Ut varius, velit blandit 
+	laoreet malesuada, tortor mauris accumsan elit, a interdum libero lectus
+	 sed mauris. Donec vitae sem a elit ultricies dictum. Donec elementum 
+	sagittis orci nec hendrerit. Cras convallis volutpat orci, quis iaculis 
+	justo hendrerit vel. Mauris ornare bibendum eros id placerat.</p>
+		<p>Pellentesque habitant morbi tristique senectus et netus et malesuada
+	 fames ac turpis egestas. Cras ac cursus orci. Nullam fermentum congue 
+	ante at dignissim. Duis rhoncus sollicitudin erat, ut eleifend magna 
+	ullamcorper ac. Fusce vitae commodo erat. Duis elementum risus ac lacus 
+	gravida posuere. Aliquam eu eros dui, quis fermentum magna. Vestibulum 
+	in arcu tortor, iaculis consectetur nisl. Vestibulum felis erat, 
+	molestie in congue id, sagittis nec ipsum. Class aptent taciti sociosqu 
+	ad litora torquent per conubia nostra, per inceptos himenaeos. Aliquam 
+	mollis tristique libero a mattis. Ut a pellentesque risus.</p>
+		<p>Cras consectetur est sit amet nulla auctor facilisis. Vivamus 
+	pretium bibendum viverra. Curabitur congue quam et felis consectetur a 
+	adipiscing libero elementum. Vestibulum ante ipsum primis in faucibus 
+	orci luctus et ultrices posuere cubilia Curae; Quisque lobortis, dui 
+	vestibulum dapibus placerat, tortor risus viverra mauris, et molestie 
+	ipsum nunc ut erat. Mauris mollis, massa ac consectetur facilisis, nulla
+	 lacus gravida arcu, vel adipiscing leo diam auctor enim. Morbi iaculis 
+	scelerisque nulla. Vestibulum vitae velit ante. Cum sociis natoque 
+	penatibus et magnis dis parturient montes, nascetur ridiculus mus. 
+	Maecenas varius eleifend commodo. Donec eu nulla risus, vel scelerisque 
+	ante. Proin a purus nibh, eu adipiscing erat. Ut vestibulum enim eget mi
+	 dictum aliquet. Cras consectetur, augue a blandit rutrum, arcu est 
+	venenatis velit, non vulputate ligula arcu quis ante. Praesent lectus 
+	mauris, consequat sit amet feugiat vitae, commodo sit amet sem.</p>
+		<p>Pellentesque molestie tincidunt leo, eu blandit mauris iaculis 
+	vitae. Donec sed convallis felis. Curabitur fringilla consectetur augue 
+	id viverra. Integer fringilla est et arcu tincidunt bibendum facilisis 
+	lectus ullamcorper. Suspendisse et nisi sed enim ullamcorper rutrum. Nam
+	 leo erat, ultricies in fringilla a, condimentum a ipsum. Proin nunc 
+	metus, tincidunt quis sagittis ut, vulputate at odio. Nulla pellentesque
+	 vulputate lectus, quis scelerisque nisi rutrum porta. Nam blandit 
+	tristique nisi. Donec placerat tristique nibh, ac placerat erat bibendum
+	 in. Mauris posuere, ipsum vel eleifend blandit, neque arcu cursus 
+	velit, ut faucibus nisl velit quis magna. Aliquam vulputate, mi ac 
+	pulvinar tempus, elit urna eleifend dolor, iaculis auctor nibh elit ac 
+	sem. Nam volutpat erat vel neque pulvinar commodo ac sed erat. Nam sed 
+	erat eu risus facilisis viverra a vel lectus. Curabitur consectetur nunc
+	 accumsan ligula aliquam ut ullamcorper arcu molestie.</p>
+		<p>Cras a augue massa. Praesent feugiat aliquam justo, ut gravida quam 
+	feugiat tristique. Suspendisse potenti. Aliquam erat volutpat. Sed 
+	sollicitudin sodales magna, sed rhoncus dui lacinia vel. Phasellus in 
+	nisi dui. Morbi condimentum, eros eget faucibus commodo, libero nulla 
+	tristique lacus, a varius ligula diam sagittis mauris. Suspendisse 
+	ultrices, sem et iaculis semper, magna erat porttitor nunc, vel rutrum 
+	nunc sapien eu nisl. Suspendisse egestas ullamcorper cursus. Nam 
+	scelerisque adipiscing accumsan. In hac habitasse platea dictumst. Ut 
+	aliquet nisi in elit fermentum rutrum. Curabitur sem leo, feugiat vel 
+	euismod eu, adipiscing sit amet sem. Quisque tempus sapien vulputate 
+	magna vulputate bibendum ullamcorper est congue. Aenean vitae nulla a 
+	lorem rutrum bibendum sit amet id mauris. Pellentesque habitant morbi 
+	tristique senectus et netus et malesuada fames ac turpis egestas. Duis a
+	 risus ac ligula pulvinar placerat nec ac felis. Quisque a massa elit, 
+	vel ornare felis. Quisque placerat, dui vel tristique facilisis, sem 
+	lectus tincidunt neque, ac iaculis lectus leo id felis.</p>
+		<p>Vestibulum sed felis diam. Vivamus ac mi semper massa tincidunt 
+	placerat. Phasellus consectetur, augue nec faucibus lobortis, diam 
+	ligula pharetra nisi, ut consequat magna leo porta mauris. Nunc vitae 
+	dolor nisi. Sed at neque nec arcu eleifend suscipit. Fusce pellentesque 
+	purus ullamcorper orci scelerisque adipiscing. Curabitur placerat mi 
+	eget tortor hendrerit vehicula in sit amet eros. Vestibulum ante ipsum 
+	primis in faucibus orci luctus et ultrices posuere cubilia Curae; Proin 
+	nec justo ac dolor dignissim pulvinar feugiat in sapien. Suspendisse 
+	tincidunt tristique risus, sed faucibus arcu sagittis eu. Nulla et 
+	dignissim tortor. Suspendisse dictum ornare velit, at viverra mi 
+	condimentum a.</p>
+	</div>
+
+	<div class="scroll-top-200">
+		<h2>Scroll Element C</h2>
+		Scroll down/up to see me smoothly reposition myself with a 200px margin and keep in view.<br><br>
 		jScroll by William Duffy<br />
 		<a href="http://www.wduffy.co.uk/">www.wduffy.co.uk</a>
 	</div>


### PR DESCRIPTION
- The value of top option is not considered when determining the visibility of
  the element. The element is scrolled after it's top offset is lower than the
  $window.scrollTop() position. Setting the top value to a bigger value e.g.
  200px shows a "jumping" effect: when scrolling the element "jumps" to it's
  correct position 200px below the browser window _after_ it scrolled off the
  window.
- This commit changes the behaviour. The top value is considered as a margin-top
  of the element, so it stays visible the whole time.
- See http://jsbin.com/uqoyef/latest for old an new behaviour.
