### PR TITLE
Adds a 'max' option so one can limit scrolling to an arbitrary position.

### DIFF
--- a/jquery.jscroll.js
+++ b/jquery.jscroll.js
@@ -56,7 +56,7 @@
 			
 			this.getMargin = function ($window)
 			{
-				var max = $element.parent().height() - $element.outerHeight();
+				var max = opts.max ? opts.max() : $element.parent().height() - $element.outerHeight();
 				var margin = this.originalMargin;
 			
 				if ($window.scrollTop() >= this.min)
@@ -74,7 +74,8 @@
     // Public: Default values
     $.fn.jScroll.defaults = {
         speed	:	"slow",
-		top		:	10
+		top		:	10,
+		max : null
     };
 
 })(jQuery);


### PR DESCRIPTION
Here's an example:

```
var node1 = $(…)
var node2 = $(…)
node2.jScroll({
  max: function() {
    return node1.offset().top;
  }
});
```

Which won't allow scrolling past node1.
